### PR TITLE
Small typo in documentation

### DIFF
--- a/docs/source/user_guide/grid_search.rst
+++ b/docs/source/user_guide/grid_search.rst
@@ -29,7 +29,7 @@ First, let's load some data.
     X = data[0]
     y = data[1]
 
-Now, we need to define which hyperparameter sets we wan to include in the
+Now, we need to define which hyperparameter sets we want to include in the
 grid search, we do so by defining a dictionary with hyperparameter-values pairs
 and scikit-learn will automatically generate all possible combinations. For the
 dictionary below, we can generate 16 combinations (4*2*2).

--- a/docs/source/user_guide/grid_search.rst
+++ b/docs/source/user_guide/grid_search.rst
@@ -5,7 +5,7 @@ A common practice in Machine Learning is to train several models with different
 hyperparameters and compare the performance across hyperparameter sets.
 scikit-learn provides a tool to do it: :class:`sklearn.grid_search.GridSearchCV`, which trains the same model
 with different parameters. When doing grid search, it is tempting to just take
-the 'best model' and carry on, but analizing the results can give us some
+the 'best model' and carry on, but analyzing the results can give us some
 interesting information, so it's worth taking a look at the results.
 
 sklearn-evaluation includes a plotting function to evaluate grid search results, this way we can see how the model performs when changing one (or two)


### PR DESCRIPTION
changed "analizing" to "analyzing" in [Evaluating Grid Search Results](https://sklearn-evaluation.readthedocs.io/en/latest/user_guide/grid_search.html) line 4.