### PR TITLE
telemetry action attribute added to Plot functions

### DIFF
--- a/src/sklearn_evaluation/plot/classification.py
+++ b/src/sklearn_evaluation/plot/classification.py
@@ -84,10 +84,12 @@ class ConfusionMatrix(Plot):
 
         _plot_cm(self.cm, cmap, ax, self.target_names, self.normalize)
 
+    @SKLearnEvaluationLogger.log(feature='plot', action='confusion-matrix-sub')
     def __sub__(self, other):
         cm = self.cm - other.cm
         return ConfusionMatrixSub(cm, self.target_names)
 
+    @SKLearnEvaluationLogger.log(feature='plot', action='confusion-matrix-add')
     def __add__(self, other):
         return ConfusionMatrixAdd(self.cm, other.cm, self.target_names)
 
@@ -187,7 +189,8 @@ def confusion_matrix(
 
 def _confusion_matrix_validate_predictions(y_true, y_pred, target_names):
     if any((val is None for val in (y_true, y_pred))):
-        raise ValueError("y_true and y_pred are needed to plot confusion " "matrix")
+        raise ValueError(
+            "y_true and y_pred are needed to plot confusion " "matrix")
 
     # calculate how many names you expect
     values = set(y_true).union(set(y_pred))
@@ -197,7 +200,8 @@ def _confusion_matrix_validate_predictions(y_true, y_pred, target_names):
         raise ValueError(
             (
                 "Data cointains {} different values, but target"
-                " names contains {} values.".format(expected_len, len(target_names))
+                " names contains {} values.".format(
+                    expected_len, len(target_names))
             )
         )
 
@@ -223,7 +227,8 @@ def _confusion_matrix_init_defaults(cmap, ax):
 
 
 def _confusion_matrix_validate(y_true, y_pred, target_names, cmap, ax):
-    target_names = _confusion_matrix_validate_predictions(y_true, y_pred, target_names)
+    target_names = _confusion_matrix_validate_predictions(
+        y_true, y_pred, target_names)
     cmap, ax = _confusion_matrix_init_defaults(cmap, ax)
     return target_names, cmap, ax
 
@@ -239,7 +244,8 @@ def _add_values_to_matrix(m, ax):
             label = "{:.2}".format(v)
         except Exception:
             label = v
-        ax.text(x, y, label, horizontalalignment="center", verticalalignment="center")
+        ax.text(x, y, label, horizontalalignment="center",
+                verticalalignment="center")
 
 
 def _plot_cm(cm, cmap, ax, target_names, normalize):

--- a/src/sklearn_evaluation/plot/classification_report.py
+++ b/src/sklearn_evaluation/plot/classification_report.py
@@ -6,6 +6,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.metrics import classification_report as sk_classification_report
 from matplotlib.figure import Figure
+from ..telemetry import SKLearnEvaluationLogger
 
 from sklearn_evaluation.plot.classification import _add_values_to_matrix
 from sklearn_evaluation.util import default_heatmap
@@ -24,14 +25,16 @@ def _classification_report_add(first, second, keys, target_names, ax):
     ax.set_yticks(tick_marks)
     ax.set_yticklabels(target_names)
 
-    ax.set(title="Classification report (compare)", xlabel="Metric", ylabel="Class")
+    ax.set(title="Classification report (compare)",
+           xlabel="Metric", ylabel="Class")
 
 
 class ClassificationReportSub(Plot):
     def __init__(self, matrix, matrix_another, keys, target_names) -> None:
         self.figure = Figure()
         ax = self.figure.add_subplot()
-        _classification_report_plot(matrix - matrix_another, keys, target_names, ax)
+        _classification_report_plot(
+            matrix - matrix_another, keys, target_names, ax)
         ax.set(title="Classification report (difference)")
 
 
@@ -39,7 +42,8 @@ class ClassificationReportAdd(Plot):
     def __init__(self, matrix, matrix_another, keys, target_names) -> None:
         self.figure = Figure()
         self.ax = self.figure.add_subplot()
-        _classification_report_add(matrix, matrix_another, keys, target_names, self.ax)
+        _classification_report_add(
+            matrix, matrix_another, keys, target_names, self.ax)
 
 
 class ClassificationReport(Plot):
@@ -49,7 +53,7 @@ class ClassificationReport(Plot):
     --------
     .. plot:: ../../examples/ClassificationReport.py
     """
-
+    @SKLearnEvaluationLogger.log(feature='plot', action='classification-report-init')
     def __init__(
         self,
         y_true,
@@ -85,13 +89,16 @@ class ClassificationReport(Plot):
                 zero_division=zero_division,
             )
 
-        _classification_report_plot(self.matrix, self.keys, self.target_names, ax)
+        _classification_report_plot(
+            self.matrix, self.keys, self.target_names, ax)
 
+    @SKLearnEvaluationLogger.log(feature='plot', action='classification-report-sub')
     def __sub__(self, other):
         return ClassificationReportSub(
             self.matrix, other.matrix, self.keys, target_names=self.target_names
         )
 
+    @SKLearnEvaluationLogger.log(feature='plot', action='classification-report-add')
     def __add__(self, other):
         return ClassificationReportAdd(
             self.matrix, other.matrix, keys=self.keys, target_names=self.target_names
@@ -156,7 +163,8 @@ def _classification_report(
         output_dict=True,
     )
 
-    report = {k: v for k, v in report.items() if "avg" not in k and k != "accuracy"}
+    report = {k: v for k, v in report.items(
+    ) if "avg" not in k and k != "accuracy"}
     n_classes = len(report.keys())
 
     target_names = target_names or [str(i) for i in range(n_classes)]

--- a/src/sklearn_evaluation/plot/roc.py
+++ b/src/sklearn_evaluation/plot/roc.py
@@ -212,7 +212,7 @@ class ROC(Plot):
     -----
     .. versionadded:: 0.8.4
     """
-    @SKLearnEvaluationLogger.log(feature='plot')
+    @SKLearnEvaluationLogger.log(feature='plot', action='roc-init')
     def __init__(self, y_true, y_score,
                  fpr=None, tpr=None, ax=None):
 
@@ -273,7 +273,7 @@ class ROC(Plot):
     def __sub__(self):
         raise NotImplementedError("Not applicable for ROC")
 
-    @SKLearnEvaluationLogger.log(feature='plot')
+    @SKLearnEvaluationLogger.log(feature='plot', action='roc-add')
     def __add__(self, other):
         return ROCAdd(self, other)
 


### PR DESCRIPTION
`@SKLearnEvaluationLogger` takes the running function name as the default `action`. Since we changed our Plot API to implement `def __init__()`, `def __add__()`, and `def __sub()` - the telemetry is not categorized properly and is not clear enough.

I specified the actions for these methods, and also added missing telemetry to `ClassificationReport` and `ConfusionMatrix`.

i.e:
```python
@SKLearnEvaluationLogger.log(feature='plot', action='roc-init')

@SKLearnEvaluationLogger.log(feature='plot', action='roc-add')
```