### PR TITLE
Ci timeout

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,7 @@ import nox
 )
 def tests(session):
     session.install("pip", "--upgrade")
+    session.install("pytest-timeout")
 
     # if we remove the --editable flag pytest throws an error, because there
     # are two copies of the pkg (src/ and site-packages/), this is a quick
@@ -43,6 +44,7 @@ def tests(session):
         "--cov=sklearn_evaluation",
         "--doctest-modules",
         "--verbose",
+        "--timeout=30",
     )
     session.run("coveralls")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,6 @@ import nox
 )
 def tests(session):
     session.install("pip", "--upgrade")
-    session.install("pytest-timeout")
 
     # if we remove the --editable flag pytest throws an error, because there
     # are two copies of the pkg (src/ and site-packages/), this is a quick
@@ -43,8 +42,6 @@ def tests(session):
         "examples/",
         "--cov=sklearn_evaluation",
         "--doctest-modules",
-        "--verbose",
-        "--timeout=120",
     )
     session.run("coveralls")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -44,7 +44,7 @@ def tests(session):
         "--cov=sklearn_evaluation",
         "--doctest-modules",
         "--verbose",
-        "--timeout=30",
+        "--timeout=120",
     )
     session.run("coveralls")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ def tests(session):
         "examples/",
         "--cov=sklearn_evaluation",
         "--doctest-modules",
+        "--verbose",
     )
     session.run("coveralls")
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ JB = [
 
 TEST = [
     "jupytext",
-    "papermill",
+    "ploomber-engine",
     "ipykernel",
     "pytest",
     # need to pin this version because pytest 4 breaks matplotlib image

--- a/tests/nb/conftest.py
+++ b/tests/nb/conftest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import jupytext
 import nbformat
-import papermill as pm
+from ploomber_engine import execute_notebook
 import pytest
 
 
@@ -19,7 +19,7 @@ def save_notebook(nb_str, path, execute=True, parameters=None):
     nbformat.write(nb, path)
 
     if execute:
-        pm.execute_notebook(str(path), str(path), parameters=parameters or {})
+        execute_notebook(str(path), str(path), parameters=parameters or {})
 
     return str(path)
 


### PR DESCRIPTION
## Describe your changes

fixed the error causing the CI to get stuck due to the recent jupyter_client 8 release. migrating notebook execution to ploomber-engine fixes the problem

## Issue ticket number and link
Closes #x 

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] I have added thorough [tests](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#testing) (when necessary).
- [ ] I have added the right documentation in the [docstring](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#documenting-changes-and-new-features) and [changelog](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#changelog) (when needed)



<!-- readthedocs-preview sklearn-evaluation start -->
----
:books: Documentation preview :books:: https://sklearn-evaluation--256.org.readthedocs.build/en/256/

<!-- readthedocs-preview sklearn-evaluation end -->