### PR TITLE
adds `upsert_append` to `SQLiteTracker`

### DIFF
--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -98,6 +98,17 @@ def test_upsert():
     assert len(tracker) == 1
 
 
+def test_upsert_append():
+    tracker = SQLiteTracker(":memory:")
+
+    uuid = tracker.new()
+    tracker.update(uuid, dict(a=1, b=2, c=[1], d=[4]))
+    tracker.upsert_append(uuid, dict(a=2, c=3, d=[5], e=[6]))
+
+    assert tracker.get(uuid) == dict(a=[1, 2], b=2, c=[1, 3], d=[4, 5], e=[6])
+    assert len(tracker) == 1
+
+
 def test_reprs():
     tracker = SQLiteTracker(":memory:")
     assert "SQLiteTracker" in repr(tracker)


### PR DESCRIPTION
## Describe your changes
Implemented ```upsert_append()``` which appends the new parameters to the existing key instead of replacing them
## Issue ticket number and link
Closes #274 

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I have added thorough [tests](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#testing) (when necessary).
- [ ] I have added the right documentation in the [docstring](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#documenting-changes-and-new-features) and [changelog](https://github.com/ploomber/contributing/blob/main/CONTRIBUTING.md#changelog) (when needed)



<!-- readthedocs-preview sklearn-evaluation start -->
----
:books: Documentation preview :books:: https://sklearn-evaluation--313.org.readthedocs.build/en/313/

<!-- readthedocs-preview sklearn-evaluation end -->